### PR TITLE
Fix self-contained publish layout and warning details

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using System.Text;
 
 using ThermoFisher.CommonCore.BackgroundSubtraction;
 using ThermoFisher.CommonCore.Data;
@@ -476,6 +477,74 @@ internal static class Program
         }
         return output_paths;
     }
+
+    private static Exception UnwrapThreadManagerException(Exception exception)
+    {
+        Exception current = exception;
+        while (true)
+        {
+            Exception? next = current switch
+            {
+                TargetInvocationException { InnerException: not null } targetInvocationException => targetInvocationException.InnerException,
+                TypeInitializationException { InnerException: not null } typeInitializationException => typeInitializationException.InnerException,
+                AggregateException { InnerExceptions.Count: 1 } aggregateException => aggregateException.InnerExceptions[0],
+                _ => null
+            };
+
+            if (next == null)
+            {
+                return current;
+            }
+
+            current = next;
+        }
+    }
+
+    private static string DescribeExceptionChain(Exception exception)
+    {
+        List<string> parts = new List<string>();
+        Exception? current = exception;
+        while (current != null)
+        {
+            parts.Add($"{current.GetType().FullName}: {current.Message}");
+            current = current.InnerException;
+        }
+
+        return string.Join(" --> ", parts);
+    }
+
+    private static string FormatThreadManagerException(Exception exception)
+    {
+        Exception rootCause = UnwrapThreadManagerException(exception);
+        StringBuilder builder = new StringBuilder();
+        builder.Append("Root cause: ");
+        builder.Append(rootCause.GetType().FullName);
+        builder.Append(": ");
+        builder.Append(rootCause.Message);
+
+        string exceptionChain = DescribeExceptionChain(exception);
+        string rootCauseSummary = $"{rootCause.GetType().FullName}: {rootCause.Message}";
+        if (!string.Equals(exceptionChain, rootCauseSummary, StringComparison.Ordinal))
+        {
+            builder.AppendLine();
+            builder.Append("Exception chain: ");
+            builder.Append(exceptionChain);
+        }
+
+        string? stackTrace = !string.IsNullOrWhiteSpace(rootCause.StackTrace)
+            ? rootCause.StackTrace
+            : exception.StackTrace;
+        if (!string.IsNullOrWhiteSpace(stackTrace))
+        {
+            builder.AppendLine();
+            builder.Append("Stack trace:");
+            builder.AppendLine();
+            builder.Append(stackTrace.Trim());
+        }
+
+        return builder.ToString();
+    }
+
     static void ProcessFile(string inputFile, string outputFile, int batchSize, int scanThreads, int scanChunkSize)
     {
         //var myThreadManager = RawFileReaderFactory.CreateThreadManager("/Users/n.t.wamsley/Desktop/20230324_OLEP08_200ng_30min_E20H50Y30_180K_2Th3p5ms_02.raw");
@@ -641,10 +710,12 @@ internal static class Program
                 scanThreadManager = null;
                 scanParallelOptions = null;
                 Console.WriteLine(
-                    "Warning: scan-thread mode unavailable for {0} ({1}: {2}). Falling back to single-thread scan extraction.",
-                    Path.GetFileNameWithoutExtension(inputFile),
-                    ex.GetType().Name,
-                    ex.Message);
+                    "Warning: scan-thread mode unavailable for {0}. Falling back to single-thread scan extraction.",
+                    Path.GetFileName(inputFile));
+                Console.WriteLine(
+                    "Warning details:{0}{1}",
+                    Environment.NewLine,
+                    FormatThreadManagerException(ex));
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are three ways to get **PioneerConverter**:
 
    On Apple Silicon, Thermo RawFileReader is x64-only, so PioneerConverter runs via Rosetta 2.
    The macOS arm64 installer will install Rosetta automatically when needed.
-3. **Precompiled binaries** – Zipped binaries are available for Linux, macOS, and Windows. Each archive contains a `bin` directory with the `PioneerConverter` executable and a `lib` directory with its dependencies. Extract them anywhere and, on Linux or macOS, you may need to run `chmod +x bin/PioneerConverter` before executing.
+3. **Precompiled binaries** – Zipped binaries are available for Linux, macOS, and Windows. Each archive contains a `bin` directory with the `PioneerConverter` executable and the self-contained runtime files that must stay beside it, plus a `lib` directory with packaged libraries. Keep the extracted layout intact and, on Linux or macOS, you may need to run `chmod +x bin/PioneerConverter` before executing.
 4. **Build from source** – If you prefer to build the tool yourself, follow the steps in the [Build from source](#build-from-source) section below.
 
 ## Usage

--- a/build.sh
+++ b/build.sh
@@ -51,8 +51,7 @@ build_linux() {
     print_step "Building for Linux x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r linux-x64 \
-      -p:PublishSingleFile=true \
-      -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishSingleFile=false \
       -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
@@ -61,9 +60,9 @@ build_linux() {
       --self-contained true \
       -o dist/PioneerConverter-linux-x64
 
-    chmod +x dist/PioneerConverter-linux-x64/PioneerConverter
     mkdir -p dist/PioneerConverter-linux-x64/bin
-    mv dist/PioneerConverter-linux-x64/PioneerConverter dist/PioneerConverter-linux-x64/bin/
+    find dist/PioneerConverter-linux-x64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec mv {} dist/PioneerConverter-linux-x64/bin/ \;
+    chmod +x dist/PioneerConverter-linux-x64/bin/PioneerConverter
 }
 
 build_windows() {
@@ -72,8 +71,7 @@ build_windows() {
     print_step "Building for Windows x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r win-x64 \
-      -p:PublishSingleFile=true \
-      -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishSingleFile=false \
       -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
@@ -83,7 +81,7 @@ build_windows() {
       -o dist/PioneerConverter-win-x64
 
     mkdir -p dist/PioneerConverter-win-x64/bin
-    mv dist/PioneerConverter-win-x64/PioneerConverter.exe dist/PioneerConverter-win-x64/bin/
+    find dist/PioneerConverter-win-x64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec mv {} dist/PioneerConverter-win-x64/bin/ \;
 }
 
 BUILT=()

--- a/installers/linux/README.md
+++ b/installers/linux/README.md
@@ -1,6 +1,6 @@
 # Linux Installer
 
-The `build_deb.sh` script creates a Debian package that installs the binaries under `/usr/local/PioneerConverter` and places a wrapper script `PioneerConverter` in `/usr/local/bin`.
+The `build_deb.sh` script creates a Debian package that installs the application under `/usr/local/PioneerConverter`, with the executable and its self-contained runtime payload under `/usr/local/PioneerConverter/bin`, and places a wrapper script `PioneerConverter` in `/usr/local/bin`.
 
 ## Building
 

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -9,4 +9,4 @@ The `PioneerConverter.iss` script can be built with [Inno Setup](https://jrsoftw
 3. Compile the script to generate `PioneerConverter-win-<version>-Setup.exe`,
    where `<version>` matches the release tag.
 
-The installer places the application in `Program Files\\PioneerConverter` and optionally adds the directory to your `PATH`.
+The installer places the application in `Program Files\\PioneerConverter`. The `bin` subdirectory contains `PioneerConverter.exe` and the runtime files it needs, and the optional PATH step adds that `bin` directory.


### PR DESCRIPTION
Summary
- update Windows/Linux publishes to keep the runtime files beside `bin/PioneerConverter` instead of single-file, keeping macOS intact
- document the new layout in README and installer docs and ensure binaries stay executable in distributed archives
- improve the threaded RAW reader warning so it logs the unwrapped cause, exception chain, and stack trace for easier investigation

Testing
- Not run (not requested)